### PR TITLE
Remove obsolete wheezy.list

### DIFF
--- a/wheezy.list
+++ b/wheezy.list
@@ -1,4 +1,0 @@
-# Mopidy APT archive
-# Built on Debian 7 (wheezy), compatible with Ubuntu 14.04 LTS
-deb http://apt.mopidy.com/ wheezy main contrib non-free
-deb-src http://apt.mopidy.com/ wheezy main contrib non-free


### PR DESCRIPTION
Neither `dists/` nor `reprepro/conf/distributions` list it, and a local test verified that this suite is not available anymore.