### PR TITLE
Specify path to archive signing keys

### DIFF
--- a/buster.list
+++ b/buster.list
@@ -1,4 +1,4 @@
 # Mopidy APT archive
 # Built on Debian 10 (buster), compatible with Ubuntu 19.10 and newer
-deb https://apt.mopidy.com/ buster main contrib non-free
-deb-src https://apt.mopidy.com/ buster main contrib non-free
+deb [signed-by=/usr/local/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free
+deb-src [signed-by=/usr/local/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free


### PR DESCRIPTION
Related to docs change at mopidy/mopidy#2044