### PR TITLE
Use Debian default keyring path.

### DIFF
--- a/bullseye.list
+++ b/bullseye.list
@@ -1,4 +1,4 @@
 # Mopidy APT archive
 # Built on Debian 11 (bullseye), compatible with Ubuntu 22.04 LTS and newer
-deb [signed-by=/usr/local/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free
-deb-src [signed-by=/usr/local/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free
+deb [signed-by=/usr/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free
+deb-src [signed-by=/usr/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free

--- a/bullseye.list
+++ b/bullseye.list
@@ -1,4 +1,4 @@
 # Mopidy APT archive
 # Built on Debian 11 (bullseye), compatible with Ubuntu 22.04 LTS and newer
-deb [signed-by=/usr/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free
-deb-src [signed-by=/usr/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free
+deb [signed-by=/etc/apt/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free
+deb-src [signed-by=/etc/apt/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free

--- a/buster.list
+++ b/buster.list
@@ -1,4 +1,4 @@
 # Mopidy APT archive
 # Built on Debian 10 (buster), compatible with Ubuntu 19.10 and newer
-deb [signed-by=/usr/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free
-deb-src [signed-by=/usr/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free
+deb [signed-by=/etc/apt/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free
+deb-src [signed-by=/etc/apt/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free

--- a/buster.list
+++ b/buster.list
@@ -1,4 +1,4 @@
 # Mopidy APT archive
 # Built on Debian 10 (buster), compatible with Ubuntu 19.10 and newer
-deb [signed-by=/usr/local/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free
-deb-src [signed-by=/usr/local/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free
+deb [signed-by=/usr/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free
+deb-src [signed-by=/usr/share/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ buster main contrib non-free


### PR DESCRIPTION
As per https://wiki.debian.org/DebianRepository/UseThirdParty

Fixes mopidy/mopidy#2069