### PR TITLE
Add Debian Trixie suite with riscv64 architecture

### DIFF
--- a/reprepro/conf/distributions
+++ b/reprepro/conf/distributions
@@ -13,3 +13,11 @@ Architectures: i386 amd64 armel armhf arm64 source
 Components: main non-free contrib
 SignWith: 9E36464A7C030945EEB7632878FD980E271D2943
 Tracking: minimal
+
+Origin: Mopidy
+Suite: testing
+Codename: trixie
+Architectures: i386 amd64 armel armhf arm64 riscv64 source
+Components: main non-free contrib
+SignWith: 9E36464A7C030945EEB7632878FD980E271D2943
+Tracking: minimal

--- a/reprepro/conf/incoming
+++ b/reprepro/conf/incoming
@@ -9,3 +9,9 @@ IncomingDir: incoming/bookworm/
 TempDir: incoming/temp/
 Allow: unstable>bookworm
 Cleanup: unused_buildinfo_files
+
+Name: trixie
+IncomingDir: incoming/trixie/
+TempDir: incoming/temp/
+Allow: unstable>trixie
+Cleanup: unused_buildinfo_files

--- a/trixie.list
+++ b/trixie.list
@@ -1,0 +1,4 @@
+# Mopidy APT archive
+# Built on Debian 13 (trixie).
+deb [signed-by=/etc/apt/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com trixie main contrib non-free
+deb-src [signed-by=/etc/apt/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com trixie main contrib non-free

--- a/trixie.sources
+++ b/trixie.sources
@@ -1,0 +1,5 @@
+Types: deb deb-src
+URIs: https://apt.mopidy.com
+Suites: trixie
+Components: main contrib non-free
+Signed-By: /etc/apt/keyrings/mopidy-archive-keyring.gpg


### PR DESCRIPTION
Debian Trixie release is scheduled for August 9th: https://release.debian.org/

Since all packages are Python, hence architecture-agnostic, I was wondering whether it wouldn't be easier to use the `all` architecture only, like Debian does: https://packages.debian.org/trixie/mopidy
This would allow the Mopidy repo to work on any architecture Debian supports.

Furthermore, since all distro suites use the same packages, I was wondering whether it wouldn't be easier to use a single `stable` (example) suite from now on, leaving the old suites in place until they become obsolete, but add `stable` instead of `trixie` now, and never need to rotate for a new Debian release anymore.

But maybe it is intended to keep the option open, to add packages in the future with per-architecture and/or per-distro compatibility.